### PR TITLE
Adds missing sbt-native-packager support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
-
 OptimusBuild.settings
+
+enablePlugins(JavaAppPackaging)
 
 resolvers ++= Seq(
   "typesafe" at "http://repo.typesafe.com/typesafe/releases/",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.6")


### PR DESCRIPTION
Fixes issue #8 -- Adds missing `sbt-native-packager` plugin to sbt and enables `JavaAppPackaging` when calling `sbt dist` from command line interface.
