### PR TITLE
Update LPSolve instructions for homebrew.

### DIFF
--- a/docs/building_and_linking.md
+++ b/docs/building_and_linking.md
@@ -57,7 +57,7 @@ $ sudo port install lp_solve
 
 [Homebrew](http://brew.sh):
 ```bash
-$ brew tap homebrew/science
+$ brew tap brewsci/science
 $ brew install lp_solve
 ```
 


### PR DESCRIPTION
Turns out `homebrew/science` has been deprecated, when trying to install I get 
```
➜ brew tap homebrew/science
Error: homebrew/science was deprecated. This tap is now empty as all its formulae were migrated.
```
We can use `brewsci/science` instead as `lp_solve` doesn't appear to have been migrated into the primary repo.