### PR TITLE
Update ojAlgo to 47.1.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
     final val ScalaCheck = "1.14.0"
 
     final val LpSolve = "5.5.2.0"
-    final val ojAlgorithms = "47.0.0"
+    final val ojAlgorithms = "47.1.2"
     final val Trove = "3.1.0"
     final val ScalaXML = "1.2.0"
     final val Enums = "1.5.14"

--- a/solver-oj/src/main/scala/optimus/optimization/oJSolver.scala
+++ b/solver-oj/src/main/scala/optimus/optimization/oJSolver.scala
@@ -244,6 +244,5 @@ final class oJSolver extends MPSolver {
   def setTimeout(limit: Int): Unit = {
     require(0 <= limit)
     underlyingSolver.options.time_abort = limit
-    underlyingSolver.options.time_suffice = limit
   }
 }

--- a/solver-oj/src/main/scala/optimus/optimization/oJSolver.scala
+++ b/solver-oj/src/main/scala/optimus/optimization/oJSolver.scala
@@ -244,5 +244,6 @@ final class oJSolver extends MPSolver {
   def setTimeout(limit: Int): Unit = {
     require(0 <= limit)
     underlyingSolver.options.time_abort = limit
+    underlyingSolver.options.time_suffice = limit
   }
 }

--- a/solver-oj/src/main/scala/optimus/optimization/oJSolver.scala
+++ b/solver-oj/src/main/scala/optimus/optimization/oJSolver.scala
@@ -19,7 +19,7 @@ package optimus.optimization
 import optimus.algebra.ExpressionType.GENERIC
 import optimus.algebra._
 import optimus.algebra.{ ConstraintRelation, Expression }
-import org.ojalgo.constant.BigMath
+import org.ojalgo.function.constant.BigMath
 import org.ojalgo.optimisation.{ ExpressionsBasedModel, Optimisation, Variable }
 import optimus.optimization.model.INFINITE
 import optimus.optimization.enums.{ PreSolve, SolutionStatus }


### PR DESCRIPTION
I found this error in production using ojSolver that I couldn't reproduce elsewhere :
`java.lang.IllegalStateException: Requires a count/size greater than the limit!` linked ot this issue in ojAlgo: https://github.com/optimatika/ojAlgo/issues/170.
I wanted to update ojAlgo to the latest version (48.1.0) but some tests didn't pass. So I've update it to the last one that allow the Optimus test to complete and fixes the bug.
Fix #34  