### PR TITLE
Fix multiplication bug on One object

### DIFF
--- a/core/src/main/scala/optimus/algebra/Expression.scala
+++ b/core/src/main/scala/optimus/algebra/Expression.scala
@@ -11,7 +11,7 @@
  *          \/////       \///             \/////    \///  \///   \///   \///  \/////////   \//////////
  *
  * The mathematical programming library for Scala.
- *     
+ *
  */
 
 package optimus.algebra
@@ -235,7 +235,7 @@ case object Zero extends Const(0) {
 
 case object One extends Const(1) {
 
-  override def *(expression: Expression): Expression = this
+  override def *(expression: Expression): Expression = expression
 
   override def unary_- : Const = Const(-1)
 }

--- a/core/src/test/scala/optimus/algebra/AlgebraSpecTest.scala
+++ b/core/src/test/scala/optimus/algebra/AlgebraSpecTest.scala
@@ -11,7 +11,7 @@
  *          \/////       \///             \/////    \///  \///   \///   \///  \/////////   \//////////
  *
  * The mathematical programming library for Scala.
- *     
+ *
  */
 
 package optimus.algebra
@@ -324,6 +324,14 @@ final class AlgebraSpecTest extends AnyFunSpec with Matchers {
 
     it("constraint_1 should NOT be equal to constraint_2") {
       constraint_1.equals(constraint_2) shouldEqual false
+    }
+  }
+
+  describe("Limit cases") {
+    def multiply(ex: Expression, d: Double): Expression = ex * d
+
+    it("1 * c should be equal to c (and not to 1)") {
+      multiply(One, 10.0) shouldBe Const(10.0)
     }
   }
 }


### PR DESCRIPTION
I found a cryptic bug that can be traced out to an error on the multiplication definition on One.